### PR TITLE
Add format options

### DIFF
--- a/lib/resize.js
+++ b/lib/resize.js
@@ -12,7 +12,7 @@ const resize = (file, cfg, cb) => {
 	const task = sharp(file.contents)
 	task.resize(cfg.maxWidth, cfg.maxHeight || null)
 	task.max()
-	if (cfg.format) task.toFormat(cfg.format)
+	if (cfg.format) task.toFormat(cfg.format, cfg.formatOptions)
 	task.withoutEnlargement(!cfg.allowEnlargement)
 
 	task.toBuffer((err, data, info) => {

--- a/test/index.js
+++ b/test/index.js
@@ -11,6 +11,7 @@ const Vinyl = require('vinyl')
 const createPlugin = require('..')
 const {SHARP_INFO} = createPlugin
 const defaultComputeFileName = require('../lib/compute-file-name')
+const resize = require('../lib/resize')
 
 const src = path.join(__dirname, 'teacup-and-saucer.jpg')
 
@@ -193,5 +194,40 @@ test('defaultComputeFileName', (t) => {
 		t.equal(fileName, 'bar.700w.jpeg')
 	})
 })
+
+pTest('formatOptions are passed to sharp', co.wrap(function* (t) {
+	const file = yield vFile.read(src)
+
+	const file1 = file.clone()
+	const scale1 = {
+		format: 'webp',
+		maxWidth: 100,
+		formatOptions: {
+			quality: 80
+		},
+		maxWidth: Number.MAX_SAFE_INTEGER
+	}
+	const defaultFileSize = yield new Promise((res) => resize(file1, scale1, (err, newFile1) => {
+		t.ifError(err)
+		res(newFile1[SHARP_INFO].size)
+	}))
+
+	const file2 = file.clone()
+	const scale2 = {
+		format: 'webp',
+		maxWidth: 100,
+		formatOptions: {
+			quality: 100
+		},
+		maxWidth: Number.MAX_SAFE_INTEGER
+	}
+
+	resize(file2, scale2, (err, newFile2) => {
+		t.ifError(err)
+		t.ok(newFile2[SHARP_INFO].size > defaultFileSize)
+	});
+
+	t.end()
+}))
 
 // todo: >1 files

--- a/test/index.js
+++ b/test/index.js
@@ -208,8 +208,10 @@ pTest('formatOptions are passed to sharp', co.wrap(function* (t) {
 		maxWidth: Number.MAX_SAFE_INTEGER
 	}
 	const defaultFileSize = yield new Promise((res, rej) => resize(file1, scale1, (err, newFile1) => {
-		if (err) rej(err);
-		res(newFile1[SHARP_INFO].size)
+		if (err)
+			rej(err)
+		else
+			res(newFile1[SHARP_INFO].size)
 	}))
 
 	const file2 = file.clone()
@@ -223,9 +225,12 @@ pTest('formatOptions are passed to sharp', co.wrap(function* (t) {
 	}
 
 	yield new Promise((res, rej) => resize(file2, scale2, (err, newFile2) => {
-		if (err) rej(err)
-		t.ok(newFile2[SHARP_INFO].size > defaultFileSize)
-		res()
+		if (err)
+			rej(err)
+		else {
+			t.ok(newFile2[SHARP_INFO].size > defaultFileSize)
+			res()
+		}
 	}));
 
 	t.end()

--- a/test/index.js
+++ b/test/index.js
@@ -207,8 +207,8 @@ pTest('formatOptions are passed to sharp', co.wrap(function* (t) {
 		},
 		maxWidth: Number.MAX_SAFE_INTEGER
 	}
-	const defaultFileSize = yield new Promise((res) => resize(file1, scale1, (err, newFile1) => {
-		t.ifError(err)
+	const defaultFileSize = yield new Promise((res, rej) => resize(file1, scale1, (err, newFile1) => {
+		if (err) rej(err);
 		res(newFile1[SHARP_INFO].size)
 	}))
 
@@ -222,10 +222,11 @@ pTest('formatOptions are passed to sharp', co.wrap(function* (t) {
 		maxWidth: Number.MAX_SAFE_INTEGER
 	}
 
-	resize(file2, scale2, (err, newFile2) => {
-		t.ifError(err)
+	yield new Promise((res, rej) => resize(file2, scale2, (err, newFile2) => {
+		if (err) rej(err)
 		t.ok(newFile2[SHARP_INFO].size > defaultFileSize)
-	});
+		res()
+	}));
 
 	t.end()
 }))


### PR DESCRIPTION
Add format options object which is passed to sharp processor as discussed in #12 

p.s. travis is green for everything except latest node, it can't install sharp there somewhy. 