### PR TITLE
remove dot from extname

### DIFF
--- a/lib/compute-file-name.js
+++ b/lib/compute-file-name.js
@@ -10,7 +10,7 @@ const defaultComputeFileName = (output, scale, cb) => {
 	const ext = path.extname(output.path)
 	const fileName = [path.basename(output.path, ext)]
 	if (suffix.length > 0) fileName.push(suffix.join('-'))
-	fileName.push(scale.format || ext)
+	fileName.push(scale.format || ext.split('.').pop())
 
 	cb(null, fileName.join('.'))
 }

--- a/lib/compute-file-name.js
+++ b/lib/compute-file-name.js
@@ -10,7 +10,7 @@ const defaultComputeFileName = (output, scale, cb) => {
 	const ext = path.extname(output.path)
 	const fileName = [path.basename(output.path, ext)]
 	if (suffix.length > 0) fileName.push(suffix.join('-'))
-	fileName.push(scale.format || ext.split('.').pop())
+	fileName.push(scale.format || ext.slice(1))
 
 	cb(null, fileName.join('.'))
 }


### PR DESCRIPTION
Fixes the double dots before file extension if `format` is not specified in `file.scale`