### PR TITLE
Add image resizing fit

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ const createScaleImagesPlugin = (computeFileName = defaultComputeFileName) => {
 		if (s.format && 'string' !== typeof s.format) {
 			return onErr('file.scale.format must be a string')
 		}
-		if (s.fit && 'string' !== typeof s.format) {
+		if (s.fit && 'string' !== typeof s.fit) {
 			return onErr('file.scale.fit must be a string')
 		}
 		if (s.withoutEnlargement && 'boolean' !== typeof s.withoutEnlargement) {

--- a/index.js
+++ b/index.js
@@ -42,6 +42,9 @@ const createScaleImagesPlugin = (computeFileName = defaultComputeFileName) => {
 		if (s.format && 'string' !== typeof s.format) {
 			return onErr('file.scale.format must be a string')
 		}
+		if (s.fit && 'string' !== typeof s.format) {
+			return onErr('file.scale.fit must be a string')
+		}
 		if (s.withoutEnlargement && 'boolean' !== typeof s.withoutEnlargement) {
 			return onErr('file.scale.withoutEnlargement must be a boolean')
 		}

--- a/lib/resize.js
+++ b/lib/resize.js
@@ -10,10 +10,11 @@ const SHARP_INFO = require('./sharp-info')
 
 const resize = (file, cfg, cb) => {
 	const task = sharp(file.contents)
-	task.resize(cfg.maxWidth, cfg.maxHeight || null, {
+	var opts = {
 		withoutEnlargement: !cfg.allowEnlargement,
-		fit: 'inside'
-	})
+	}
+	if (cfg.fit) opts.fit = cfg.fit
+	task.resize(cfg.maxWidth, cfg.maxHeight || null, opts)
 	if (cfg.format) task.toFormat(cfg.format, cfg.formatOptions)
 
 	task.toBuffer((err, data, info) => {

--- a/lib/resize.js
+++ b/lib/resize.js
@@ -11,7 +11,8 @@ const SHARP_INFO = require('./sharp-info')
 const resize = (file, cfg, cb) => {
 	const task = sharp(file.contents)
 	task.resize(cfg.maxWidth, cfg.maxHeight || null, {
-		withoutEnlargement: !cfg.allowEnlargement
+		withoutEnlargement: !cfg.allowEnlargement,
+		fit: 'inside'
 	})
 	if (cfg.format) task.toFormat(cfg.format, cfg.formatOptions)
 

--- a/readme.md
+++ b/readme.md
@@ -22,10 +22,11 @@ npm install gulp-scale-images --save-dev
 
 ```js
 {
-	maxWidth: 300, // optional maximum width, respecting the aspect ratio
-	maxHeight: 400, // optional maximum height, respecting the aspect ratio
+	maxWidth: 300, // optional maximum width
+	maxHeight: 400, // optional maximum height
 	format: 'jpeg', // optional, one of ('jpeg', 'png', 'webp')
 	withoutEnlargement: false, // optional, default is true
+	fit: 'inside' // optional, default is 'cover', one of ('cover', 'contain', 'fill', 'inside', 'outside')
 	formatOptions: {} // optional, additional format options for sharp engine
 }
 ```

--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@ npm install gulp-scale-images --save-dev
 	maxHeight: 400, // optional maximum height
 	format: 'jpeg', // optional, one of ('jpeg', 'png', 'webp')
 	withoutEnlargement: false, // optional, default is true
-	fit: 'inside' // optional, default is 'cover', one of ('cover', 'contain', 'fill', 'inside', 'outside')
+	fit: 'inside', // optional, default is 'cover', one of ('cover', 'contain', 'fill', 'inside', 'outside')
 	formatOptions: {} // optional, additional format options for sharp engine
 }
 ```


### PR DESCRIPTION
Related to issue #17, a non-breaking change that adds an optional `fit` parameter that defaults to Sharp's default.