### PR TITLE
Update Sharp to version 0.23 for Node 13 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "gulp-scale-images",
 	"description": "Gulp plugin to resize each image into multiple smaller variants.",
-	"version": "1.2.2",
+	"version": "1.2.3",
 	"main": "index.js",
 	"files": [
 		"index.js",
@@ -29,7 +29,7 @@
 	},
 	"dependencies": {
 		"plugin-error": "^1.0.1",
-		"sharp": "^0.22.1",
+		"sharp": "^0.23.1",
 		"through2": "^3.0.0"
 	},
 	"devDependencies": {


### PR DESCRIPTION
Sharp 0.22 doesn't have a build target for Node 13, updating it to version 0.23 allows Node 13 users to use this package